### PR TITLE
Fix turbo-modules guide removing the double import

### DIFF
--- a/docs/turbo-modules.md
+++ b/docs/turbo-modules.md
@@ -461,7 +461,6 @@ This file defines the interface for the `RTNCalculator` module. Here, we can add
 ##### RTNCalculator.mm
 
 ```objc title="RTNCalculator.mm"
-#import "RTNCalculatorSpec.h"
 #import "RTNCalculator.h"
 
 @implementation RTNCalculator


### PR DESCRIPTION
This extra line is not needed and it causes a Duplicated Symbols error when using frameworks.