### PR TITLE
fix: "pod-install" script by adding cd ios to ensure command execute within ios dir.

### DIFF
--- a/docs/enable-apps.md
+++ b/docs/enable-apps.md
@@ -66,7 +66,7 @@ You will need to run `pod install` each time a dependency with native code chang
 
 ```
   "scripts": {
-    "pod-install": "RCT_NEW_ARCH_ENABLED=1 bundle exec pod install"
+    "pod-install": "cd ios && RCT_NEW_ARCH_ENABLED=1 bundle exec pod install"
   }
 ```
 


### PR DESCRIPTION
fix: pod-install script by adding cd ios in the scripts. This ensures that the command is executed within the ios directory where the Podfile is located.