### PR TITLE
Add some more clarification about RCT_EXPORT_XXX

### DIFF
--- a/docs/fabric-native-components.md
+++ b/docs/fabric-native-components.md
@@ -503,7 +503,7 @@ Then, you have to expose the `text` property for the Fabric Native Component. Th
 
 > [!Note]
 > Unlike legacy native components, properties are actually handled via `updateProps` C++ code, see below.
-> Those macros are needed for the bridge, With bidgeless mode you can omit them.
+> Those macros are needed for bridge compatibility. With bidgeless mode you can omit them entirely.
 > There are other macros that can be used to export custom properties, emitters, and other constructs. You can view the code that specifies them [here](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Views/RCTViewManager.h).
 
 ##### RTNCenteredText.h

--- a/docs/fabric-native-components.md
+++ b/docs/fabric-native-components.md
@@ -502,6 +502,8 @@ The most important call is to the `RCT_EXPORT_MODULE`, which is required to expo
 Then, you have to expose the `text` property for the Fabric Native Component. This is done with the `RCT_EXPORT_VIEW_PROPERTY` macro, specifying a name and a type.
 
 > [!Note]
+> Unlike legacy native components, properties are actually handled via `updateProps` C++ code, see bellow.
+> Those macros are needed for the bridge, With bidgeless mode you can ommit them.
 > There are other macros that can be used to export custom properties, emitters, and other constructs. You can view the code that specifies them [here](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Views/RCTViewManager.h).
 
 ##### RTNCenteredText.h

--- a/docs/fabric-native-components.md
+++ b/docs/fabric-native-components.md
@@ -502,8 +502,8 @@ The most important call is to the `RCT_EXPORT_MODULE`, which is required to expo
 Then, you have to expose the `text` property for the Fabric Native Component. This is done with the `RCT_EXPORT_VIEW_PROPERTY` macro, specifying a name and a type.
 
 > [!Note]
-> Unlike legacy native components, properties are actually handled via `updateProps` C++ code, see bellow.
-> Those macros are needed for the bridge, With bidgeless mode you can ommit them.
+> Unlike legacy native components, properties are actually handled via `updateProps` C++ code, see below.
+> Those macros are needed for the bridge, With bidgeless mode you can omit them.
 > There are other macros that can be used to export custom properties, emitters, and other constructs. You can view the code that specifies them [here](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Views/RCTViewManager.h).
 
 ##### RTNCenteredText.h


### PR DESCRIPTION
They are a bit confusing as it seems to be required unless brdigeless mode is on, but properties are actually handled in updateProps:, and not with objective-c props like in legacy components

See https://github.com/reactwg/react-native-new-architecture/discussions/154
> Static ViewConfigs
>
>In addition, Bridgeless Mode optimizes component rendering with Static ViewConfigs.
>
>ViewConfigs tell React what props and events a native component supports. Prior, ViewConfigs were generated at run-time by analyzing a native component's ViewManager.
>
>With Static ViewConfigs, we move this work to build-time by analyzing a native component's Flow or TypeScript [spec file](https://reactnative.dev/docs/0.71/the-new-architecture/pillars-fabric-components#2-javascript-specification). If a native component does not have a spec file, then Bridgeless will fallback to run-time ViewConfig generation.