### PR TITLE
Specify TS/JS file name in turbo-modules-xplat.md

### DIFF
--- a/docs/turbo-modules-xplat.md
+++ b/docs/turbo-modules-xplat.md
@@ -52,7 +52,7 @@ CxxTurboModulesGuide
 
 ## 1. JavaScript Specification
 
-Create the following spec inside the `tm` folder:
+Create the following spec inside the `tm` folder (`NativeSampleModule.ts|js`):
 
 <details>
   <summary>TypeScript</summary>


### PR DESCRIPTION
The lack of clarity of a file name causes some obscure build errors during the tutorial. This needs to be clarified.