### PR TITLE
Codegen generates ReadableMap when using object literal or with Type alias or Interface

### DIFF
--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -37,7 +37,7 @@ This is recommended over using plain `Object`, for type safety.
 |   |   |
 |---|---|
 | Nullable Support? | <code>?{&#124; foo: string, ...&#124;}</code> |
-| Android (Java) | - |
+| Android (Java) | `ReadableMap` |
 | iOS | - |
 
 ### `Object`


### PR DESCRIPTION
I tried to generate the code. A literal object or with Type alias or Interface will generate the `ReadableMap`.
Not sure why it has been written in hyphen at there. Just reject this PR if there is any reason why it has been written like that.