### PR TITLE
Add target platform to iOS codegen

### DIFF
--- a/docs/fabric-native-components.md
+++ b/docs/fabric-native-components.md
@@ -411,7 +411,8 @@ yarn add ../RTNCenteredText
 cd ..
 node MyApp/node_modules/react-native/scripts/generate-codegen-artifacts.js \
   --path MyApp/ \
-  --outputPath RTNCenteredText/generated/
+  --outputPath RTNCenteredText/generated/ \
+  --targetPlatform ios
 ```
 
 This script first adds the `RTNCenteredText` module to the app with `yarn add`. Then, it invokes **Codegen** via the `generate-codegen-artifacts.js` script.


### PR DESCRIPTION
Just something that didn't work when I tried following the guide. Guess you are moving to npx react-native codegen so only a temp change this perhaps.