### PR TITLE
add missing cmake step for includesGeneratedCode=true

### DIFF
--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -278,7 +278,7 @@ Here is how you can enable this setup:
 - Update your `package.json` to include the generated code.
 - Update your [podspec](./turbo-modules.md#ios-create-the-podspec-file) to include the generated code.
 - Update your [build.gradle file](./turbo-modules.md#the-buildgradle-file) to include the generated code.
-- Update `cmakeListsPath` in `react-native.config.js` ([example](https://github.com/facebook/react-native/blob/3c17beafe387fb4966055d5dfcec62bef537e0f7/packages/react-native-popup-menu-android/react-native.config.js#L12)) so that the Gradle doesn't look for `CMakeLists` file in the `build` directory but instead in your `outputDir`.
+- Update `cmakeListsPath` in `react-native.config.js` ([example](https://github.com/facebook/react-native/blob/3c17beafe387fb4966055d5dfcec62bef537e0f7/packages/react-native-popup-menu-android/react-native.config.js#L12)) so that Gradle doesn't look for `CMakeLists` file in the `build` directory but instead in your `outputDir`.
 
 ---
 

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -278,7 +278,7 @@ Here is how you can enable this setup:
 - Update your `package.json` to include the generated code.
 - Update your [podspec](./turbo-modules.md#ios-create-the-podspec-file) to include the generated code.
 - Update your [build.gradle file](./turbo-modules.md#the-buildgradle-file) to include the generated code.
-- You may also want to add the generated code to `.gitignore`.
+- Update `cmakeListsPath` in `react-native.config.js` ([example](https://github.com/facebook/react-native/blob/3c17beafe387fb4966055d5dfcec62bef537e0f7/packages/react-native-popup-menu-android/react-native.config.js#L12)) so that the Gradle doesn't look for `CMakeLists` file in the `build` directory but instead in your `outputDir`.
 
 ---
 


### PR DESCRIPTION
fix instructions for "Including Generated Code into Libraries" on Android

On Android, an important step was missing that would cause gradle to look for cmake files in a location where they wouldn't be found.

Also removed `You may also want to add the generated code to `.gitignore``.

Happy to add it back but I don't understand why I'd want those files gitignored. By adding them to my library I'm taking over some responsibility for them and it feels odd to not version them.