### PR TITLE
Fixed code on sample turbo module in android

### DIFF
--- a/docs/turbo-modules.md
+++ b/docs/turbo-modules.md
@@ -14,9 +14,9 @@ Turbo Native Modules are the next iteration on Native Modules that provide a few
 At a high-level the steps for writing a Turbo Module are:
 
 1. Define a JavaScript specification using Flow or TypeScript.
-1. Configure the dependencies management system to generate code from the provided spec.
-1. Implement the Native code.
-1. Integrate the code in the app.
+2. Configure the dependencies management system to generate code from the provided spec.
+3. Implement the Native code.
+4. Integrate the code in the app.
 
 This guide will show you how to create a basic Turbo Native Module compatible with the latest version of React Native.
 
@@ -521,7 +521,7 @@ codegen
 ├── java
 │   └── com
 │       └── rtncalculator
-│           └── NativeCalculatorSpec.java
+│           └── NativeRTNCalculatorSpec.java
 ├── jni
 │   ├── Android.mk
 │   ├── CMakeLists.txt
@@ -579,9 +579,9 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import java.util.Map;
 import java.util.HashMap;
-import com.rtncalculator.NativeCalculatorSpec;
+import com.rtncalculator.NativeRTNCalculatorSpec;
 
-public class CalculatorModule extends NativeCalculatorSpec {
+public class CalculatorModule extends NativeRTNCalculatorSpec {
 
     public static String NAME = "RTNCalculator";
 
@@ -611,9 +611,9 @@ package com.rtncalculator
 
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.rtncalculator.NativeCalculatorSpec
+import com.rtncalculator.NativeRTNCalculatorSpec
 
-class CalculatorModule(reactContext: ReactApplicationContext) : NativeCalculatorSpec(reactContext) {
+class CalculatorModule(reactContext: ReactApplicationContext) : NativeRTNCalculatorSpec(reactContext) {
 
   override fun getName() = NAME
 
@@ -629,7 +629,7 @@ class CalculatorModule(reactContext: ReactApplicationContext) : NativeCalculator
 
 </details>
 
-This class implements the module itself, which extends the `NativeCalculatorSpec` that was generated from the `NativeCalculator` JavaScript specification file.
+This class implements the module itself, which extends the `NativeRTNCalculatorSpec` that was generated from the `NativeCalculator` JavaScript specification file.
 
 ##### Updating the `CalculatorPackage.java`
 


### PR DESCRIPTION
This is to fix the erroneous code samples in the turbo modules wiki

Thanks @cortinico for helping me:

Context: https://github.com/reactwg/react-native-new-architecture/discussions/229

P.S. I haven't tried the iOS side, But It might also need an update as well